### PR TITLE
feat: add member profile pages

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -15,7 +15,7 @@ function AdminPage() {
   const [eventDescription, setEventDescription] = useState('');
 
   const [gameDate, setGameDate] = useState('');
-  const [gamePlayers, setGamePlayers] = useState<{ userId: string; name: string; finishingPosition: number }[]>([]);
+  const [gamePlayers, setGamePlayers] = useState<{ userId: string; name: string; finishingPosition: number; winnings: number }[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [searchResults, setSearchResults] = useState<User[]>([]);
@@ -67,7 +67,7 @@ function AdminPage() {
   };
 
   const addPlayerToGame = (user: User) => {
-    setGamePlayers([...gamePlayers, { userId: user._id, name: user.name, finishingPosition: gamePlayers.length + 1 }]);
+    setGamePlayers([...gamePlayers, { userId: user._id, name: user.name, finishingPosition: gamePlayers.length + 1, winnings: 0 }]);
     setSearchTerm('');
     setSearchResults([]);
   };
@@ -166,8 +166,16 @@ function AdminPage() {
                 <span>{player.name}</span>
                 <input
                   type="number"
+                  placeholder="Position"
                   value={player.finishingPosition}
                   onChange={(e) => handlePlayerChange(index, 'finishingPosition', parseInt(e.target.value))}
+                  className="border p-2 rounded w-24"
+                />
+                <input
+                  type="number"
+                  placeholder="Winnings"
+                  value={player.winnings}
+                  onChange={(e) => handlePlayerChange(index, 'winnings', parseInt(e.target.value))}
                   className="border p-2 rounded w-24"
                 />
               </div>

--- a/src/app/api/seed/route.ts
+++ b/src/app/api/seed/route.ts
@@ -35,9 +35,9 @@ export async function GET() {
       {
         date: new Date(new Date().getTime() - 7 * 24 * 60 * 60 * 1000),
         players: [
-          { userId: userIds[0], finishingPosition: 1 },
-          { userId: userIds[1], finishingPosition: 2 },
-          { userId: userIds[2], finishingPosition: 3 },
+          { userId: userIds[0], finishingPosition: 1, winnings: 40 },
+          { userId: userIds[1], finishingPosition: 2, winnings: 20 },
+          { userId: userIds[2], finishingPosition: 3, winnings: 0 },
         ],
         buyIn: 20,
         prizePool: 60,
@@ -45,9 +45,9 @@ export async function GET() {
       {
         date: new Date(),
         players: [
-          { userId: userIds[3], finishingPosition: 1 },
-          { userId: userIds[4], finishingPosition: 2 },
-          { userId: userIds[0], finishingPosition: 3 },
+          { userId: userIds[3], finishingPosition: 1, winnings: 40 },
+          { userId: userIds[4], finishingPosition: 2, winnings: 20 },
+          { userId: userIds[0], finishingPosition: 3, winnings: 0 },
         ],
         buyIn: 20,
         prizePool: 60,

--- a/src/app/api/users/[userId]/profile/route.ts
+++ b/src/app/api/users/[userId]/profile/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from 'next/server';
+import { connectToDatabase } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const { userId } = params;
+    const { db } = await connectToDatabase();
+
+    const user = await db.collection('users').findOne({ _id: new ObjectId(userId) });
+
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    const games = await db.collection('games').find({ 'players.userId': new ObjectId(userId) }).toArray();
+
+    let totalWinnings = 0;
+    const gameHistory = games.map((game) => {
+      const player = game.players.find((p: any) => p.userId.toHexString() === userId);
+      totalWinnings += player.winnings;
+      return {
+        _id: game._id,
+        date: game.date,
+        winnings: player.winnings,
+        finishingPosition: player.finishingPosition,
+      };
+    });
+
+    return NextResponse.json({
+      name: user.name,
+      totalWinnings,
+      games: gameHistory,
+    }, { status: 200 });
+
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { message: 'An internal server error occurred' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { connectToDatabase } from '@/lib/mongodb';
+import { ObjectId } from 'mongodb';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { userId: string } }
+) {
+  try {
+    const { userId } = params;
+    const { db } = await connectToDatabase();
+
+    const user = await db.collection('users').findOne(
+      { _id: new ObjectId(userId) },
+      { projection: { name: 1 } }
+    );
+
+    if (!user) {
+      return NextResponse.json({ message: 'User not found' }, { status: 404 });
+    }
+
+    return NextResponse.json({ user }, { status: 200 });
+  } catch (error) {
+    console.error(error);
+    return NextResponse.json(
+      { message: 'An internal server error occurred' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -32,13 +32,21 @@ export default function LoginPage() {
     if (res.ok) {
       const { token } = await res.json();
       const decoded: DecodedToken = jwtDecode(token);
-      const user = { id: decoded.userId, name: 'Test User', email, role: decoded.role }; // In a real app, you'd fetch the user's name
-      dispatch(loginSuccess({ user, token }));
 
-      if (decoded.role === 'admin') {
-        router.push('/admin');
+      // Fetch user details to get the name
+      const userRes = await fetch(`/api/users/${decoded.userId}`);
+      if (userRes.ok) {
+        const { user: userDetails } = await userRes.json();
+        const user = { id: decoded.userId, name: userDetails.name, email, role: decoded.role };
+        dispatch(loginSuccess({ user, token }));
+
+        if (decoded.role === 'admin') {
+          router.push('/admin');
+        } else {
+          router.push('/members');
+        }
       } else {
-        router.push('/members');
+        alert('Failed to fetch user details.');
       }
     } else {
       const { message } = await res.json();

--- a/src/app/members/[userId]/page.tsx
+++ b/src/app/members/[userId]/page.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useParams } from 'next/navigation';
+
+interface UserProfile {
+  name: string;
+  totalWinnings: number;
+  games: {
+    _id: string;
+    date: string;
+    winnings: number;
+    finishingPosition: number;
+  }[];
+}
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const params = useParams();
+  const { userId } = params;
+
+  useEffect(() => {
+    if (userId) {
+      const fetchProfile = async () => {
+        const res = await fetch(`/api/users/${userId}/profile`); // This route doesn't exist yet
+        if (res.ok) {
+          const data = await res.json();
+          setProfile(data);
+        }
+      };
+      fetchProfile();
+    }
+  }, [userId]);
+
+  if (!profile) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <main className="min-h-screen p-4 sm:p-8">
+      <h1 className="text-4xl font-bold mb-8">{profile.name}'s Profile</h1>
+      <h2 className="text-2xl font-bold mb-4">Total Winnings: ${profile.totalWinnings}</h2>
+      <h3 className="text-xl font-bold mb-4">Game History</h3>
+      <table className="w-full text-left">
+        <thead>
+          <tr>
+            <th className="p-2">Date</th>
+            <th className="p-2">Position</th>
+            <th className="p-2">Winnings</th>
+          </tr>
+        </thead>
+        <tbody>
+          {profile.games.map((game) => (
+            <tr key={game._id}>
+              <td className="p-2">{new Date(game.date).toLocaleDateString()}</td>
+              <td className="p-2">{game.finishingPosition}</td>
+              <td className="p-2">${game.winnings}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </main>
+  );
+}


### PR DESCRIPTION
This commit adds profile pages for each member, which display a record of their winnings.

- Updates the database schema to include a `winnings` field.
- Updates the admin page and API to handle the new `winnings` field.
- Creates a new dynamic route and profile page component at `/members/[userId]`.
- Creates a new API route to fetch the detailed game history and total winnings for a specific user.